### PR TITLE
Avoid DWrite FontSetBuilder crash in CanvasFontSet::GetSystemFontSet

### DIFF
--- a/winrt/lib/text/CanvasFontSet.cpp
+++ b/winrt/lib/text/CanvasFontSet.cpp
@@ -74,15 +74,30 @@ IFACEMETHODIMP CanvasFontSetFactory::GetSystemFontSet(
         [&]
         {
             CheckAndClearOutPointer(fontSet);
-            
+
             auto factory = CustomFontManager::GetInstance()->GetSharedFactory();
 
             ComPtr<DWriteFontSetType> systemFonts;
 
-            ComPtr<DWriteFontSetType> systemFontsIncludingRemoteFonts;
-
-            ThrowIfFailed(As<IDWriteFactory3>(factory)->GetSystemFontSet(&systemFontsIncludingRemoteFonts));
-            systemFonts = GetLocalFonts(systemFontsIncludingRemoteFonts);
+            // Prefer IDWriteFactory6::GetSystemFontSet(includeDownloadableFonts=FALSE), which
+            // returns a local-only system font set directly. The IDWriteFactory3 path below has
+            // to filter remote fonts via IDWriteFontSetBuilder::CreateFontSet, which has been
+            // observed to AV inside DWrite (FontSetBuilder::WriteRegion) on some user machines.
+            // IDWriteFactory6 is available on Windows 10 1903+; fall back to the older path on
+            // earlier versions (WinAppSDK min target is 1809).
+            ComPtr<IDWriteFactory6> factory6;
+            if (SUCCEEDED(factory.As(&factory6)))
+            {
+                ComPtr<IDWriteFontSet1> localSystemFonts;
+                ThrowIfFailed(factory6->GetSystemFontSet(FALSE, &localSystemFonts));
+                ThrowIfFailed(localSystemFonts.As(&systemFonts));
+            }
+            else
+            {
+                ComPtr<DWriteFontSetType> systemFontsIncludingRemoteFonts;
+                ThrowIfFailed(As<IDWriteFactory3>(factory)->GetSystemFontSet(&systemFontsIncludingRemoteFonts));
+                systemFonts = GetLocalFonts(systemFontsIncludingRemoteFonts);
+            }
 
             auto canvasFontSet = ResourceManager::GetOrCreate<ICanvasFontSet>(systemFonts.Get());
 


### PR DESCRIPTION
## Summary

User crash reports from production all terminate in DWrite's `FontSetBuilder::WriteRegion` / `CreateFontSetRegionInMemory` / `DWriteFontSetBuilder::CreateFontSet`, called from Win2D's `CanvasFontSet::GetSystemFontSet` → `GetLocalFonts` path (14 identical stacks collected). This is upstream-known but unfixed (microsoft/Win2D#863 open, microsoft/Win2D#759 closed-no-fix).

Root cause: `GetLocalFonts` filters out remote fonts by feeding local `IDWriteFontFaceReference`s into an `IDWriteFontSetBuilder` and calling `CreateFontSet`. DWrite AVs inside that call for some users (Roboto via Control Panel, Office 365 cloud fonts, etc.).

Fix: prefer `IDWriteFactory6::GetSystemFontSet(includeDownloadableFonts=FALSE, ...)` (Windows 10 1903+), which returns a local-only system font set directly and bypasses the buggy builder round-trip. Falls back to the existing `IDWriteFactory3` path on Windows 10 1809 (the WinAppSDK min target).

- New API matches existing header: `dwrite_3.h` declares `IDWriteFactory6::GetSystemFontSet(BOOL, IDWriteFontSet1**)` and `IDWriteFontSet1 : public IDWriteFontSet`, so the `As<IDWriteFontSet>()` is trivial.
- `MockDWriteFactory` only chains up to `IDWriteFactory3`, so unit tests in `CanvasFontSetUnitTests.cpp` will fail the QI and continue to exercise the fallback path — no test changes required.
- Stack signatures of representative crash dumps stored at `C:\Users\ThinhDb\Downloads\TextCrashLogs` (14 files, all identical at frames 0-2).

## Test plan
- [ ] Build the WinAppSDK Win2D solution (couldn't be verified locally — the `pkgs.dev.azure.com/shine-oss/Win2D-Dependencies` package feed requires auth this environment doesn't have).
- [ ] Run existing `CanvasFontSet` unit tests (`CanvasFontSet_GetSystemFontSet`, `CanvasFontSet_GetSystemFontSet_RemovesRemoteFonts`). These should still pass via the fallback path.
- [ ] Smoke test in the Drawboard app on a 1903+ machine that previously hit the crash (e.g. install Roboto via Control Panel and reboot, per microsoft/Win2D#863 repro).
- [ ] Confirm fallback path still works on a Win10 1809 VM (optional — same code as before).

## What was NOT done
- I couldn't compile the change in this environment (the internal Azure DevOps NuGet feed requires credentials). The change is small and the new API surface was verified directly against `dwrite_3.h` in the Windows SDK, but a clean build from a CI machine is needed before merge.
- No new test was added for the `IDWriteFactory6` branch because `MockDWriteFactory` would need to be extended to chain through `IDWriteFactory4/5/6`. Happy to do that in a follow-up if reviewers want explicit coverage of both branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)