### PR TITLE
Package Release PDBs in the Win2D.uwp NuGet

### DIFF
--- a/build/Win2D.cpp.props
+++ b/build/Win2D.cpp.props
@@ -152,10 +152,14 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <ControlFlowGuard>Guard</ControlFlowGuard>
+      <!-- Emit debug info (/Zi) even in Release so an optimized build still produces a PDB. -->
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <!-- Generate the linker PDB (/DEBUG) alongside the optimized binary. -->
+      <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
 

--- a/build/nuget/Win2D.uwp.nuspec
+++ b/build/nuget/Win2D.uwp.nuspec
@@ -57,5 +57,10 @@
     <file target="runtimes\win-x64\native\Microsoft.Graphics.Canvas.dll" src="$bin$\UAPx64\release\winrt.dll.UAP\Microsoft.Graphics.Canvas.dll" />
     <file target="runtimes\win-x86\native\Microsoft.Graphics.Canvas.dll" src="$bin$\UAPx86\release\winrt.dll.UAP\Microsoft.Graphics.Canvas.dll" />
 
+    <file target="runtimes\win-arm64\native\Microsoft.Graphics.Canvas.pdb" src="$bin$\UAPARM64\release\winrt.dll.UAP\Microsoft.Graphics.Canvas.pdb" />
+    <file target="runtimes\win-arm\native\Microsoft.Graphics.Canvas.pdb" src="$bin$\UAPARM\release\winrt.dll.UAP\Microsoft.Graphics.Canvas.pdb" />
+    <file target="runtimes\win-x64\native\Microsoft.Graphics.Canvas.pdb" src="$bin$\UAPx64\release\winrt.dll.UAP\Microsoft.Graphics.Canvas.pdb" />
+    <file target="runtimes\win-x86\native\Microsoft.Graphics.Canvas.pdb" src="$bin$\UAPx86\release\winrt.dll.UAP\Microsoft.Graphics.Canvas.pdb" />
+
   </files>
 </package>


### PR DESCRIPTION
## Summary

Release builds already generate a PDB for the native `Microsoft.Graphics.Canvas.dll` — the shipped `Win2D.uwp` 1.28.3 x64 binary carries an RSDS debug directory referencing `Microsoft.Graphics.Canvas.pdb` (GUID `04B9EF40-D0CD-49AB-AFF8-CC0B21D0EBC1`, age `41`). But `Win2D.uwp.nuspec` never listed the `.pdb`, so symbols were dropped from the package. As a result, crash dumps from the shipped package can't be symbolicated without the original build machine's PDB.

## Changes

- **`build/nuget/Win2D.uwp.nuspec`** — package `Microsoft.Graphics.Canvas.pdb` next to each arch's native DLL under `runtimes\win-<arch>\native\`.
- **`build/Win2D.cpp.props`** — make Release debug-info generation explicit (`DebugInformationFormat=ProgramDatabase` + `GenerateDebugInformation`) so packaging can't silently regress if a toolset default changes. `OptimizeReferences`/`COMDATFolding` are unchanged, so code generation is unaffected — this only adds symbols.

## Verification needed

I could not build the UWP package in my environment (heavy native/UWP build). Before merge/release, please:
- Build the package via `build.cmd` and confirm each `runtimes\win-<arch>\native\` folder contains a `Microsoft.Graphics.Canvas.pdb`.
- Confirm the built DLL still carries an RSDS entry whose GUID/age matches the packaged PDB.

## Note on existing production dumps

This fixes symbolication **going forward only**. Existing dumps from 1.28.3 match strictly by build-id (GUID `04B9EF40…`, age `41`) and require the *original* PDB from the build machine (`c:\dev\drawboard\win2d\bin\uapx64\release\winrt.dll.uap\Microsoft.Graphics.Canvas.pdb`); a fresh rebuild produces a different GUID and won't match.